### PR TITLE
Add multiarch builds

### DIFF
--- a/docker/mock-onelogin/Dockerfile
+++ b/docker/mock-onelogin/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.21 as build-env
+FROM --platform=$BUILDPLATFORM golang:1.21 as build-env
+
+ARG TARGETARCH
 
 RUN apt-get install -y --no-install-recommends openssl
 
@@ -8,7 +10,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY cmd/mock-onelogin ./cmd/mock-onelogin
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o mock-onelogin ./cmd/mock-onelogin
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -installsuffix cgo -o mock-onelogin ./cmd/mock-onelogin
 
 RUN addgroup --system app && \
   adduser --system --gecos app app && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ministryofjustice/opg-mock-onelogin
 
-go 1.21.1
+go 1.21
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.0


### PR DESCRIPTION
# Purpose

Fixes up the dockerfile to abide by the multi-arch build that the CI is using. This means we'll get arm64 images.

## Approach

https://www.sobyte.net/post/2022-03/building-multi-architecture-images-with-docker-buildx/

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* I have updated documentation where relevant
* I have added tests to prove my work
* I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
