### PR TITLE
allow mlpab and ual teams to review PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @ministryofjustice/opg-webops
+*       @ministryofjustice/opg-webops @ministryofjustice/opg-modernising-lpa-team @ministryofjustice/opg-use-a-lpa-team


### PR DESCRIPTION
# Purpose

Allow teams that use this mock to review PRs

## Approach

- add modernising lpa team and use a lpa team as codeowners

## Learning

- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners_