### PR TITLE
OpenID configuration missing logout endpoint.

### DIFF
--- a/main.go
+++ b/main.go
@@ -336,7 +336,7 @@ func userInfo() Handler {
 
 func logout() Handler {
 	return func(w http.ResponseWriter, r *http.Request) error {
-		idToken := r.FormValue("token")
+		idToken := r.FormValue("id_token_hint")
 		postLogoutRedirectUri := r.FormValue("post_logout_redirect_uri")
 
 		if idToken == "" && postLogoutRedirectUri != "" {

--- a/main_test.go
+++ b/main_test.go
@@ -316,7 +316,7 @@ func TestUserInfoWithIdentity(t *testing.T) {
 
 func TestLogout(t *testing.T) {
 	form := url.Values{
-		"token":                    {"testtoken"},
+		"id_token_hint":            {"testtoken"},
 		"post_logout_redirect_uri": {"http://somewhere"},
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -39,6 +39,7 @@ func TestOpenIDConfig(t *testing.T) {
 		TokenEndpoint:         "c",
 		UserinfoEndpoint:      "d",
 		JwksURI:               "e",
+		EndSessionEndpoint:    "f",
 	})
 	err := h(w, r)
 	resp := w.Result()
@@ -46,7 +47,7 @@ func TestOpenIDConfig(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	assert.JSONEq(t, `{"authorization_endpoint":"a","issuer":"b","token_endpoint":"c","userinfo_endpoint":"d","jwks_uri":"e"}`, string(body))
+	assert.JSONEq(t, `{"authorization_endpoint":"a","issuer":"b","token_endpoint":"c","userinfo_endpoint":"d","jwks_uri":"e","end_session_endpoint":"f"}`, string(body))
 }
 
 func TestJwks(t *testing.T) {
@@ -315,6 +316,7 @@ func TestUserInfoWithIdentity(t *testing.T) {
 
 func TestLogout(t *testing.T) {
 	form := url.Values{
+		"token":                    {"testtoken"},
 		"post_logout_redirect_uri": {"http://somewhere"},
 	}
 


### PR DESCRIPTION
Also matched logout parameter handling with the documented details. A token is required when specifying the optional redirect endpoint.

The default endpoint is the one-login logout success page.

Fixes UML-3016


## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* I have updated documentation where relevant
* [x] I have added tests to prove my work
* I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
