### PR TITLE
UML-3016 Should have used the public endpoint for this one. Not the internal.

### DIFF
--- a/main.go
+++ b/main.go
@@ -376,7 +376,7 @@ func run(logger *slog.Logger) error {
 		TokenEndpoint:         internalURL + "/token",
 		UserinfoEndpoint:      internalURL + "/userinfo",
 		JwksURI:               internalURL + "/.well-known/jwks",
-		EndSessionEndpoint:    internalURL + "/logout",
+		EndSessionEndpoint:    publicURL + "/logout",
 	}
 
 	templates, err := template.ParseFiles("web/templates/authorize.gohtml")


### PR DESCRIPTION
# Purpose

Used the wrong url for the logout endpoint. It's a publicly accessed one and so should use the defined PUBLIC_URL

Fixes UML-3016

## Learning

Test changes locally

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* I have updated documentation where relevant
* [x] I have added tests to prove my work
* I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
