### PR TITLE
MLPAB-1876: Add option for unable to ID flow

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,14 +23,15 @@ import (
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 var (
-	clientId           = envGet("CLIENT_ID", "theClientId")
-	internalURL        = envGet("INTERNAL_URL", "http://mock-onelogin:8080")
-	port               = envGet("PORT", "8080")
-	publicURL          = envGet("PUBLIC_URL", "http://localhost:8080")
-	serviceRedirectUrl = envGet("REDIRECT_URL", "http://localhost:5050/auth/redirect")
-	templateHeader     = os.Getenv("TEMPLATE_HEADER") == "1"
-	templateSub        = os.Getenv("TEMPLATE_SUB") == "1"
-	templateEmail      = os.Getenv("TEMPLATE_EMAIL")
+	clientId            = envGet("CLIENT_ID", "theClientId")
+	internalURL         = envGet("INTERNAL_URL", "http://mock-onelogin:8080")
+	port                = envGet("PORT", "8080")
+	publicURL           = envGet("PUBLIC_URL", "http://localhost:8080")
+	serviceRedirectUrl  = envGet("REDIRECT_URL", "http://localhost:5050/auth/redirect")
+	templateHeader      = os.Getenv("TEMPLATE_HEADER") == "1"
+	templateSub         = os.Getenv("TEMPLATE_SUB") == "1"
+	templateEmail       = os.Getenv("TEMPLATE_EMAIL")
+	templateReturnCodes = os.Getenv("TEMPLATE_RETURN_CODES") == "1"
 
 	tokenSigningKey, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	tokenSigningKid    = randomString("kid-", 8)
@@ -193,10 +194,11 @@ func token(kid, clientId, issuer string) Handler {
 }
 
 type authorizeTemplateData struct {
-	Identity bool
-	Header   bool
-	Sub      bool
-	Email    string
+	Identity    bool
+	Header      bool
+	Sub         bool
+	Email       string
+	ReturnCodes bool
 }
 
 func authorize(tmpl interface {
@@ -221,10 +223,11 @@ func authorize(tmpl interface {
 
 		if r.Method == http.MethodGet {
 			return tmpl.Execute(w, authorizeTemplateData{
-				Identity: returnIdentity,
-				Header:   templateHeader,
-				Sub:      templateSub,
-				Email:    templateEmail,
+				Identity:    returnIdentity,
+				Header:      templateHeader,
+				Sub:         templateSub,
+				Email:       templateEmail,
+				ReturnCodes: templateReturnCodes,
 			})
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -243,7 +243,7 @@ func TestAuthorizePost(t *testing.T) {
 				},
 			},
 		},
-		"cannot prove identity": {
+		"unsuccessful identity check with return code": {
 			form: url.Values{
 				"redirect_uri": {"http://localhost:5050/auth/redirect"},
 				"state":        {"my-state"},
@@ -331,7 +331,7 @@ func TestUserInfoWithIdentity(t *testing.T) {
 	assert.Contains(t, data["https://vocab.account.gov.uk/v1/coreIdentityJWT"], "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lkZW50aXR5LmFjY291bnQuZ292LnVrLyIsInN1YiI6Im15LXN1YiIsImF1ZCI6WyJ0aGVDbGllbnRJZCJdLCJleHAiOjE1Nzc5MzQ0MjUsIm5iZiI6MTU3NzkzNDI0NSwiaWF0IjoxNTc3OTM0MjQ1LCJ2b3QiOiJQMiIsInZ0bSI6Imh0dHBzOi8vb2lkYy5hY2NvdW50Lmdvdi51ay90cnVzdG1hcmsiLCJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMjAwMC0wMS0wMiJ9XSwibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJTYW0ifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJTbWl0aCJ9XSwidmFsaWRGcm9tIjoiMjAwMC0wMS0wMSJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl19fQ.")
 }
 
-func TestUserInfoWithIdentityUnableToProveIdentity(t *testing.T) {
+func TestUserInfoWithIdentityUnsuccessfulIdentityCheckWithReturnCode(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
 	r.Header.Add("Authorization", "Bearer my-token")

--- a/main_test.go
+++ b/main_test.go
@@ -243,6 +243,23 @@ func TestAuthorizePost(t *testing.T) {
 				},
 			},
 		},
+		"cannot prove identity": {
+			form: url.Values{
+				"redirect_uri": {"http://localhost:5050/auth/redirect"},
+				"state":        {"my-state"},
+				"nonce":        {"my-nonce"},
+				"vtr":          {`["Cl.Cm.P2"]`},
+				"claims":       {`{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null}}`},
+				"return-code":  {"X"},
+			},
+			session: sessionData{
+				email:      "simulate-delivered@notifications.service.gov.uk",
+				nonce:      "my-nonce",
+				sub:        "urn:fdc:mock-one-login:2023:QMykNslde7HiDDtluNUVQUUnFpbu1ZAKiOr/QZ6sY34=",
+				identity:   true,
+				returnCode: "X",
+			},
+		},
 	}
 
 	for name, tc := range testcases {
@@ -312,6 +329,40 @@ func TestUserInfoWithIdentity(t *testing.T) {
 	assert.Equal(t, true, data["phone_verified"])
 	assert.Equal(t, float64(1311280970), data["updated_at"])
 	assert.Contains(t, data["https://vocab.account.gov.uk/v1/coreIdentityJWT"], "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lkZW50aXR5LmFjY291bnQuZ292LnVrLyIsInN1YiI6Im15LXN1YiIsImF1ZCI6WyJ0aGVDbGllbnRJZCJdLCJleHAiOjE1Nzc5MzQ0MjUsIm5iZiI6MTU3NzkzNDI0NSwiaWF0IjoxNTc3OTM0MjQ1LCJ2b3QiOiJQMiIsInZ0bSI6Imh0dHBzOi8vb2lkYy5hY2NvdW50Lmdvdi51ay90cnVzdG1hcmsiLCJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMjAwMC0wMS0wMiJ9XSwibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJTYW0ifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJTbWl0aCJ9XSwidmFsaWRGcm9tIjoiMjAwMC0wMS0wMSJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl19fQ.")
+}
+
+func TestUserInfoWithIdentityUnableToProveIdentity(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Add("Authorization", "Bearer my-token")
+
+	tokens["my-token"] = sessionData{
+		sub:        "my-sub",
+		email:      "my-email",
+		identity:   true,
+		returnCode: "X",
+	}
+
+	h := userInfo()
+	err := h(w, r)
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+
+	var data map[string]any
+	json.Unmarshal(body, &data)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "my-sub", data["sub"])
+	assert.Equal(t, "my-email", data["email"])
+	assert.Equal(t, true, data["email_verified"])
+	assert.Equal(t, "01406946277", data["phone"])
+	assert.Equal(t, true, data["phone_verified"])
+	assert.Equal(t, float64(1311280970), data["updated_at"])
+	assert.Contains(t,
+		data["https://vocab.account.gov.uk/v1/returnCode"],
+		map[string]interface{}{"code": "X"},
+	)
 }
 
 func TestLogout(t *testing.T) {

--- a/web/templates/authorize.gohtml
+++ b/web/templates/authorize.gohtml
@@ -73,13 +73,21 @@
                 </fieldset>
               </div>
             </div>
-            <div class="govuk-radios__divider">or</div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="unable-to-id" name="return-code" type="radio" value="X">
-              <label class="govuk-label govuk-radios__label" for="unable-to-id">
-                Unable to prove identity
-              </label>
-            </div>
+            {{ if .ReturnCodes }}
+              <div class="govuk-radios__divider">or</div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="unsuccessful-id-check-1" name="return-code" type="radio" value="X">
+                <label class="govuk-label govuk-radios__label" for="unsuccessful-id-check-1">
+                  Unable to prove identity (X)
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="unsuccessful-id-check-2" name="return-code" type="radio" value="T">
+                <label class="govuk-label govuk-radios__label" for="unsuccessful-id-check-2">
+                  Failed identity check (T)
+                </label>
+              </div>
+            {{ end }}
 
           </div>
         </fieldset>

--- a/web/templates/authorize.gohtml
+++ b/web/templates/authorize.gohtml
@@ -73,6 +73,13 @@
                 </fieldset>
               </div>
             </div>
+            <div class="govuk-radios__divider">or</div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="unable-to-id" name="return-code" type="radio" value="X">
+              <label class="govuk-label govuk-radios__label" for="unable-to-id">
+                Unable to prove identity
+              </label>
+            </div>
 
           </div>
         </fieldset>


### PR DESCRIPTION
# Purpose

Adds functionality to assist testing of [MLPAB-1876](https://opgtransform.atlassian.net/browse/MLPAB-1876)

## Approach

Adds unable-to-prove ID and failed identity options to the mock. This returns a `https://vocab.account.gov.uk/v1/returnCode` claim from `/userinfo` that contains a failure code of `X` (which will be our flag to start the vouching route) or `T` to simulate a failed ID check where details don't match.

## Learning

From testing out how the flow is [supposed to work](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/prove-users-identity/#understand-your-user-s-return-code-claim) on our current GOL integration account we aren't able to receive the correct response when answering unable to prove ID in GOL. I've raised this with the GOL team in our GDS channel as there's a line in the docs stating the `https://vocab.account.gov.uk/v1/returnCode` claim needs to be manually activated on integration accounts.


[MLPAB-1876]: https://opgtransform.atlassian.net/browse/MLPAB-1876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ