### PR TITLE
MLPAB-2122: Add address for preset user identities and custom fields

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  mock-onelogin:
+    build:
+      dockerfile: Dockerfile
+    ports:
+      - "6060:8080"
+    environment:
+      TEMPLATE_HEADER: "1"
+      TEMPLATE_SUB: "1"
+      PUBLIC_URL: "http://localhost:6060"
+      TEMPLATE_RETURN_CODES: "1"

--- a/main.go
+++ b/main.go
@@ -226,6 +226,7 @@ func authorize(tmpl interface {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		returnIdentity := false
 		useReturnCodes := false
+		returnAddress := false
 
 		if r.FormValue("claims") != "" {
 			var claims struct {
@@ -242,6 +243,10 @@ func authorize(tmpl interface {
 
 			if _, ok := claims.UserInfo["https://vocab.account.gov.uk/v1/returnCode"]; ok {
 				useReturnCodes = true
+			}
+
+			if _, ok := claims.UserInfo["https://vocab.account.gov.uk/v1/address"]; ok {
+				returnAddress = true
 			}
 		}
 
@@ -297,7 +302,12 @@ func authorize(tmpl interface {
 			returnCode = r.FormValue("return-code")
 		}
 
-		user, address := userDetails(r.PostForm)
+		user, a := userDetails(r.PostForm)
+
+		address := CredentialAddress{}
+		if returnAddress {
+			address = a
+		}
 
 		sessions[code] = sessionData{
 			email:      email,

--- a/main.go
+++ b/main.go
@@ -67,6 +67,8 @@ type sessionData struct {
 	identity bool
 	// returnCode to respond with (for failure to ID)
 	returnCode string
+	// address associated with the user
+	address CredentialAddress
 }
 
 type OpenIdConfig struct {
@@ -91,14 +93,31 @@ type JWTIdToken struct {
 }
 
 type UserInfoResponse struct {
-	Sub             string           `json:"sub"`
-	Email           string           `json:"email"`
-	EmailVerified   bool             `json:"email_verified"`
-	Phone           string           `json:"phone"`
-	PhoneVerified   bool             `json:"phone_verified"`
-	UpdatedAt       int              `json:"updated_at"`
-	CoreIdentityJWT string           `json:"https://vocab.account.gov.uk/v1/coreIdentityJWT,omitempty"`
-	ReturnCode      []ReturnCodeInfo `json:"https://vocab.account.gov.uk/v1/returnCode,omitempty"`
+	Sub             string              `json:"sub"`
+	Email           string              `json:"email"`
+	EmailVerified   bool                `json:"email_verified"`
+	Phone           string              `json:"phone"`
+	PhoneVerified   bool                `json:"phone_verified"`
+	UpdatedAt       int                 `json:"updated_at"`
+	CoreIdentityJWT string              `json:"https://vocab.account.gov.uk/v1/coreIdentityJWT,omitempty"`
+	ReturnCode      []ReturnCodeInfo    `json:"https://vocab.account.gov.uk/v1/returnCode,omitempty"`
+	Addresses       []CredentialAddress `json:"https://vocab.account.gov.uk/v1/address,omitempty"`
+}
+
+type CredentialAddress struct {
+	UPRN                           string `json:"uprn,omitempty"`
+	SubBuildingName                string `json:"subBuildingName,omitempty"`
+	BuildingName                   string `json:"buildingName,omitempty"`
+	BuildingNumber                 string `json:"buildingNumber,omitempty"`
+	DependentStreetName            string `json:"dependentStreetName,omitempty"`
+	StreetName                     string `json:"streetName,omitempty"`
+	DoubleDependentAddressLocality string `json:"doubleDependentAddressLocality,omitempty"`
+	DependentAddressLocality       string `json:"dependentAddressLocality,omitempty"`
+	AddressLocality                string `json:"addressLocality,omitempty"`
+	PostalCode                     string `json:"postalCode,omitempty"`
+	AddressCountry                 string `json:"addressCountry,omitempty"`
+	ValidFrom                      string `json:"validFrom,omitempty"`
+	ValidUntil                     string `json:"validUntil,omitempty"`
 }
 
 type ReturnCodeInfo struct {
@@ -278,13 +297,16 @@ func authorize(tmpl interface {
 			returnCode = r.FormValue("return-code")
 		}
 
+		user, address := userDetails(r.PostForm)
+
 		sessions[code] = sessionData{
 			email:      email,
 			nonce:      r.FormValue("nonce"),
-			user:       userDetails(r.PostForm),
+			user:       user,
 			sub:        sub,
 			identity:   returnIdentity,
 			returnCode: returnCode,
+			address:    address,
 		}
 
 		u.RawQuery = q.Encode()
@@ -350,6 +372,7 @@ func userInfo() Handler {
 					},
 				}
 
+				userInfo.Addresses = append(userInfo.Addresses, token.address)
 				userInfo.CoreIdentityJWT, _ = jwt.NewWithClaims(jwt.SigningMethodES256, claims).SignedString(privateKey)
 			}
 		}
@@ -437,16 +460,39 @@ func run(logger *slog.Logger) error {
 	return http.ListenAndServe(":"+port, mux)
 }
 
-func userDetails(form url.Values) user {
+func userDetails(form url.Values) (user, CredentialAddress) {
+	address := CredentialAddress{
+		BuildingNumber:           "1",
+		StreetName:               "RICHMOND PLACE",
+		DependentAddressLocality: "KINGS HEATH",
+		AddressLocality:          "BIRMINGHAM",
+		PostalCode:               "B14 7ED",
+		AddressCountry:           "GB",
+		ValidFrom:                "2021-01-01",
+	}
+
 	switch form.Get("user") {
 	case "donor":
-		return user{"Sam", "Smith", "2000-01-02"}
+		return user{"Sam", "Smith", "2000-01-02"}, address
 	case "certificate-provider":
-		return user{"Charlie", "Cooper", "1990-01-02"}
+		address.BuildingNumber = "2"
+		return user{"Charlie", "Cooper", "1990-01-02"}, address
 	case "custom":
-		return user{form.Get("first-names"), form.Get("last-name"), fmt.Sprintf("%s-%s-%s", form.Get("year"), zeroPad(form.Get("month")), zeroPad(form.Get("day")))}
+		user := user{form.Get("first-names"), form.Get("last-name"), fmt.Sprintf("%s-%s-%s", form.Get("year"), zeroPad(form.Get("month")), zeroPad(form.Get("day")))}
+
+		address := CredentialAddress{
+			BuildingNumber:           form.Get("building-number"),
+			StreetName:               form.Get("street-name"),
+			DependentAddressLocality: form.Get("line-2"),
+			AddressLocality:          form.Get("town"),
+			PostalCode:               form.Get("post-code"),
+			AddressCountry:           "GB",
+			ValidFrom:                "2021-01-01",
+		}
+
+		return user, address
 	default:
-		return user{}
+		return user{}, CredentialAddress{}
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -216,7 +216,7 @@ func TestAuthorizePost(t *testing.T) {
 				sub:   "dave",
 			},
 		},
-		"identity": {
+		"identity - donor": {
 			form: url.Values{
 				"redirect_uri": {"http://localhost:5050/auth/redirect"},
 				"state":        {"my-state"},
@@ -235,21 +235,65 @@ func TestAuthorizePost(t *testing.T) {
 					lastName:    "Smith",
 					dateOfBirth: "2000-01-02",
 				},
+				address: CredentialAddress{
+					BuildingNumber:           "1",
+					StreetName:               "RICHMOND PLACE",
+					DependentAddressLocality: "KINGS HEATH",
+					AddressLocality:          "BIRMINGHAM",
+					PostalCode:               "B14 7ED",
+					AddressCountry:           "GB",
+					ValidFrom:                "2021-01-01",
+				},
 			},
 		},
-		"custom identity": {
+		"identity - certificate provider": {
 			form: url.Values{
 				"redirect_uri": {"http://localhost:5050/auth/redirect"},
 				"state":        {"my-state"},
 				"nonce":        {"my-nonce"},
 				"vtr":          {`["Cl.Cm.P2"]`},
 				"claims":       {`{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null}}`},
-				"user":         {"custom"},
-				"first-names":  {"John"},
-				"last-name":    {"Smith"},
-				"day":          {"1"},
-				"month":        {"2"},
-				"year":         {"3"},
+				"user":         {"certificate-provider"},
+			},
+			session: sessionData{
+				email:    "simulate-delivered@notifications.service.gov.uk",
+				nonce:    "my-nonce",
+				sub:      "urn:fdc:mock-one-login:2023:QMykNslde7HiDDtluNUVQUUnFpbu1ZAKiOr/QZ6sY34=",
+				identity: true,
+				user: user{
+					firstNames:  "Charlie",
+					lastName:    "Cooper",
+					dateOfBirth: "1990-01-02",
+				},
+				address: CredentialAddress{
+					BuildingNumber:           "2",
+					StreetName:               "RICHMOND PLACE",
+					DependentAddressLocality: "KINGS HEATH",
+					AddressLocality:          "BIRMINGHAM",
+					PostalCode:               "B14 7ED",
+					AddressCountry:           "GB",
+					ValidFrom:                "2021-01-01",
+				},
+			},
+		},
+		"custom identity": {
+			form: url.Values{
+				"redirect_uri":    {"http://localhost:5050/auth/redirect"},
+				"state":           {"my-state"},
+				"nonce":           {"my-nonce"},
+				"vtr":             {`["Cl.Cm.P2"]`},
+				"claims":          {`{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null}}`},
+				"user":            {"custom"},
+				"first-names":     {"John"},
+				"last-name":       {"Smith"},
+				"day":             {"1"},
+				"month":           {"2"},
+				"year":            {"3"},
+				"building-number": {"4"},
+				"street-name":     {"5"},
+				"line-2":          {"6"},
+				"town":            {"7"},
+				"post-code":       {"8"},
 			},
 			session: sessionData{
 				email:    "simulate-delivered@notifications.service.gov.uk",
@@ -260,6 +304,15 @@ func TestAuthorizePost(t *testing.T) {
 					firstNames:  "John",
 					lastName:    "Smith",
 					dateOfBirth: "3-02-01",
+				},
+				address: CredentialAddress{
+					BuildingNumber:           "4",
+					StreetName:               "5",
+					DependentAddressLocality: "6",
+					AddressLocality:          "7",
+					PostalCode:               "8",
+					AddressCountry:           "GB",
+					ValidFrom:                "2021-01-01",
 				},
 			},
 		},
@@ -330,6 +383,15 @@ func TestUserInfoWithIdentity(t *testing.T) {
 		sub:      "my-sub",
 		email:    "my-email",
 		identity: true,
+		address: CredentialAddress{
+			BuildingNumber:           "1",
+			StreetName:               "2",
+			DependentAddressLocality: "3",
+			AddressLocality:          "4",
+			PostalCode:               "5",
+			AddressCountry:           "6",
+			ValidFrom:                "7",
+		},
 	}
 
 	h := userInfo()
@@ -349,6 +411,9 @@ func TestUserInfoWithIdentity(t *testing.T) {
 	assert.Equal(t, true, data["phone_verified"])
 	assert.Equal(t, float64(1311280970), data["updated_at"])
 	assert.Contains(t, data["https://vocab.account.gov.uk/v1/coreIdentityJWT"], "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lkZW50aXR5LmFjY291bnQuZ292LnVrLyIsInN1YiI6Im15LXN1YiIsImF1ZCI6WyJ0aGVDbGllbnRJZCJdLCJleHAiOjE1Nzc5MzQ0MjUsIm5iZiI6MTU3NzkzNDI0NSwiaWF0IjoxNTc3OTM0MjQ1LCJ2b3QiOiJQMiIsInZ0bSI6Imh0dHBzOi8vb2lkYy5hY2NvdW50Lmdvdi51ay90cnVzdG1hcmsiLCJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMjAwMC0wMS0wMiJ9XSwibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJTYW0ifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJTbWl0aCJ9XSwidmFsaWRGcm9tIjoiMjAwMC0wMS0wMSJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl19fQ.")
+	assert.Contains(t, data["https://vocab.account.gov.uk/v1/address"], map[string]interface{}{
+		"addressCountry": "6", "addressLocality": "4", "buildingNumber": "1", "dependentAddressLocality": "3", "postalCode": "5", "streetName": "2", "validFrom": "7",
+	})
 }
 
 func TestUserInfoWithIdentityUnsuccessfulIdentityCheckWithReturnCode(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -222,7 +222,7 @@ func TestAuthorizePost(t *testing.T) {
 				"state":        {"my-state"},
 				"nonce":        {"my-nonce"},
 				"vtr":          {`["Cl.Cm.P2"]`},
-				"claims":       {`{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null}}`},
+				"claims":       {`{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null,"https://vocab.account.gov.uk/v1/address":null}}`},
 				"user":         {"donor"},
 			},
 			session: sessionData{
@@ -252,7 +252,7 @@ func TestAuthorizePost(t *testing.T) {
 				"state":        {"my-state"},
 				"nonce":        {"my-nonce"},
 				"vtr":          {`["Cl.Cm.P2"]`},
-				"claims":       {`{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null}}`},
+				"claims":       {`{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null,"https://vocab.account.gov.uk/v1/address":null}}`},
 				"user":         {"certificate-provider"},
 			},
 			session: sessionData{
@@ -282,7 +282,7 @@ func TestAuthorizePost(t *testing.T) {
 				"state":           {"my-state"},
 				"nonce":           {"my-nonce"},
 				"vtr":             {`["Cl.Cm.P2"]`},
-				"claims":          {`{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null}}`},
+				"claims":          {`{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null,"https://vocab.account.gov.uk/v1/address":null}}`},
 				"user":            {"custom"},
 				"first-names":     {"John"},
 				"last-name":       {"Smith"},

--- a/web/templates/authorize.gohtml
+++ b/web/templates/authorize.gohtml
@@ -72,7 +72,35 @@
                   </div>
                 </fieldset>
               </div>
+              <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                    <h1 class="govuk-fieldset__heading">Address</h1>
+                  </legend>
+                  <div class="govuk-form-group">
+                    <label class="govuk-label" for="address-building-number">Building number</label>
+                    <input class="govuk-input govuk-input--width-10" id="address-building-number" name="building-number" type="text">
+                  </div>
+                  <div class="govuk-form-group">
+                    <label class="govuk-label" for="address-street-name">Street name</label>
+                    <input class="govuk-input govuk-!-width-two-thirds" id="address-street-name" name="street-name" type="text">
+                  </div>
+                  <div class="govuk-form-group">
+                    <label class="govuk-label" for="address-line-2">Line 2 (optional)</label>
+                    <input class="govuk-input govuk-!-width-two-thirds" id="address-line-2" name="line-2" type="text">
+                  </div>
+                  <div class="govuk-form-group">
+                    <label class="govuk-label" for="address-town">Town or city</label>
+                    <input class="govuk-input govuk-!-width-two-thirds" id="address-town" name="town" type="text">
+                  </div>
+                  <div class="govuk-form-group">
+                    <label class="govuk-label" for="address-postcode">Postcode</label>
+                    <input class="govuk-input govuk-input--width-10" id="address-postcode" name="post-code" type="text">
+                  </div>
+                </fieldset>
+              </div>
             </div>
+
             {{ if .ReturnCodes }}
               <div class="govuk-radios__divider">or</div>
               <div class="govuk-radios__item">


### PR DESCRIPTION
# Purpose

Allows testing of [MLPAB-2122](https://opgtransform.atlassian.net/browse/MLPAB-2122)

## Approach

* Adds hard-coded addresses to match MRLPA fixture donor and CP
* Adds address fields for custom identity
* Adds a compose file to spin up a local mock for manual testing

[MLPAB-2122]: https://opgtransform.atlassian.net/browse/MLPAB-2122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ