### PR TITLE
Allow a login to use a fixed subject more easily

### DIFF
--- a/main.go
+++ b/main.go
@@ -272,6 +272,8 @@ func authorize(tmpl interface {
 			sub = r.FormValue("subjectValue")
 		} else if subject == "fixed" {
 			sub = "urn:fdc:mock-one-login:2023:fixed_value"
+		} else if subject == "random" {
+			sub = randomString("urn:fdc:mock-one-login:2023:", 20)
 		}
 
 		returnCode := ""

--- a/main.go
+++ b/main.go
@@ -262,16 +262,16 @@ func authorize(tmpl interface {
 			email = "simulate-delivered@notifications.service.gov.uk"
 		}
 
-		sub := r.FormValue("sub")
-		if sub == "" {
-			if templateSub {
-				sub = randomString("sub-", 20)
-			} else {
-				h := sha256.New()
-				h.Write([]byte(email))
-				encodedEmail := base64.StdEncoding.EncodeToString(h.Sum(nil))
-				sub = "urn:fdc:mock-one-login:2023:" + encodedEmail
-			}
+		h := sha256.New()
+		h.Write([]byte(email))
+		encodedEmail := base64.StdEncoding.EncodeToString(h.Sum(nil))
+		sub := "urn:fdc:mock-one-login:2023:" + encodedEmail
+
+		subject := r.FormValue("subject")
+		if subject == "manual" && r.FormValue("subjectValue") != "" {
+			sub = r.FormValue("subjectValue")
+		} else if subject == "fixed" {
+			sub = "urn:fdc:mock-one-login:2023:fixed_value"
 		}
 
 		returnCode := ""

--- a/main_test.go
+++ b/main_test.go
@@ -194,7 +194,8 @@ func TestAuthorizePost(t *testing.T) {
 				"redirect_uri": {"http://localhost:5050/auth/redirect"},
 				"state":        {"my-state"},
 				"nonce":        {"my-nonce"},
-				"sub":          {"dave"},
+				"subject":      {"manual"},
+				"subjectValue": {"dave"},
 			},
 			session: sessionData{
 				email: "simulate-delivered@notifications.service.gov.uk",
@@ -208,12 +209,27 @@ func TestAuthorizePost(t *testing.T) {
 				"state":        {"my-state"},
 				"nonce":        {"my-nonce"},
 				"email":        {"dave@example.com"},
-				"sub":          {"dave"},
+				"subject":      {"manual"},
+				"subjectValue": {"dave"},
 			},
 			session: sessionData{
 				email: "dave@example.com",
 				nonce: "my-nonce",
 				sub:   "dave",
+			},
+		},
+		"sign-in with email and fixed sub": {
+			form: url.Values{
+				"redirect_uri": {"http://localhost:5050/auth/redirect"},
+				"state":        {"my-state"},
+				"nonce":        {"my-nonce"},
+				"email":        {"dave@example.com"},
+				"subject":      {"fixed"},
+			},
+			session: sessionData{
+				email: "dave@example.com",
+				nonce: "my-nonce",
+				sub:   "urn:fdc:mock-one-login:2023:fixed_value",
 			},
 		},
 		"identity - donor": {

--- a/web/templates/authorize.gohtml
+++ b/web/templates/authorize.gohtml
@@ -141,19 +141,19 @@
             <div class="govuk-radios" data-module="govuk-radios">
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="f-sub-2" name="subject" type="radio" value="fixed">
-                <label class="govuk-label govuk-radios__label" for="sub-2">
+                <label class="govuk-label govuk-radios__label" for="f-sub-2">
                   Fixed value (<em>urn:fdc:mock-one-login:2023:fixed_value</em>)
                 </label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="f-sub-3" name="subject" type="radio" value="random">
-                <label class="govuk-label govuk-radios__label" for="sub-3">
+                <label class="govuk-label govuk-radios__label" for="f-sub-3">
                   Random value (<em>urn:fdc:mock-one-login:2023:**********</em>)
                 </label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="f-sub-1" name="subject" type="radio" value="manual" data-aria-controls="cond-subject-1" aria-expanded="true">
-                <label class="govuk-label govuk-radios__label" for="sub-1" id="manual-label">
+                <label class="govuk-label govuk-radios__label" for="f-sub-1" id="manual-label">
                   Specify manually (leave blank to generate from email)
                 </label>
               </div>

--- a/web/templates/authorize.gohtml
+++ b/web/templates/authorize.gohtml
@@ -140,7 +140,19 @@
             </div>
             <div class="govuk-radios" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-sub-1" name="subject" type="radio" value="manual" data-aria-controls="cond-subject-1" aria-expanded="true" checked>
+                <input class="govuk-radios__input" id="f-sub-2" name="subject" type="radio" value="fixed">
+                <label class="govuk-label govuk-radios__label" for="sub-2">
+                  Fixed value (<em>urn:fdc:mock-one-login:2023:fixed_value</em>)
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="f-sub-3" name="subject" type="radio" value="random">
+                <label class="govuk-label govuk-radios__label" for="sub-3">
+                  Random value (<em>urn:fdc:mock-one-login:2023:**********</em>)
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="f-sub-1" name="subject" type="radio" value="manual" data-aria-controls="cond-subject-1" aria-expanded="true">
                 <label class="govuk-label govuk-radios__label" for="sub-1" id="manual-label">
                   Specify manually (leave blank to generate from email)
                 </label>
@@ -149,12 +161,6 @@
                 <div class="govuk-form-group">
                   <input class="govuk-input govuk-!-width-one-half" id="manual-subject" name="subjectValue" spellcheck="false" aria-describedby="manual-label">
                 </div>
-              </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-sub-2" name="subject" type="radio" value="fixed">
-                <label class="govuk-label govuk-radios__label" for="sub-2">
-                  Fixed value (<em>urn:fdc:mock-one-login:2023:fixed_value</em>)
-                </label>
               </div>
             </div>
           </fieldset>

--- a/web/templates/authorize.gohtml
+++ b/web/templates/authorize.gohtml
@@ -129,9 +129,35 @@
     {{ else }}
       {{ if .Sub }}
         <div class="govuk-form-group">
-          <label class="govuk-label govuk-label--m" for="f-sub">OneLogin sub</label>
-          <div class="govuk-hint">Sign in using a OneLogin sub (to ignore, leave empty)</div>
-          <input class="govuk-input" type="text" name="sub" id="f-sub" />
+          <fieldset class="govuk-fieldset" aria-describedby="subject-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h2 class="govuk-fieldset__heading">
+                OneLogin Subject (User ID)
+              </h2>
+            </legend>
+            <div id="subject-hint" class="govuk-hint">
+              Sign in using a OneLogin Subject
+            </div>
+            <div class="govuk-radios" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="f-sub-1" name="subject" type="radio" value="manual" data-aria-controls="cond-subject-1" aria-expanded="true" checked>
+                <label class="govuk-label govuk-radios__label" for="sub-1" id="manual-label">
+                  Specify manually (leave blank to generate from email)
+                </label>
+              </div>
+              <div class="govuk-radios__conditional" id="cond-subject-1">
+                <div class="govuk-form-group">
+                  <input class="govuk-input govuk-!-width-one-half" id="manual-subject" name="subjectValue" spellcheck="false" aria-describedby="manual-label">
+                </div>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="f-sub-2" name="subject" type="radio" value="fixed">
+                <label class="govuk-label govuk-radios__label" for="sub-2">
+                  Fixed value (<em>urn:fdc:mock-one-login:2023:fixed_value</em>)
+                </label>
+              </div>
+            </div>
+          </fieldset>
         </div>
       {{ end }}
 


### PR DESCRIPTION
# Purpose

We need to be able to test email changes on the one login side in use. This means differing the emails whilst setting arbitrary or static subjects so that we can control the logged in user.

Necessary for UAT of https://github.com/ministryofjustice/opg-use-an-lpa/pull/2743

## Approach

![Screenshot 2024-08-20 at 16 45 13](https://github.com/user-attachments/assets/0ed099dc-4097-47b9-a7bf-7ad3e3cb8492)

Some conditional radio buttons and some form logic work.

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* I have updated documentation where relevant
* [x] I have added tests to prove my work
* I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
