### PR TITLE
MLPAB-2407 Add endpoint for /.well-known/did.json

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -146,7 +146,7 @@ func TestAuthorize(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, w, template.w)
-	assert.Equal(t, authorizeTemplateData{}, template.data)
+	assert.Equal(t, authorizeTemplateData{SubDefaultManual: true}, template.data)
 }
 
 func TestAuthorizeWithIdentity(t *testing.T) {
@@ -165,7 +165,7 @@ func TestAuthorizeWithIdentity(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, w, template.w)
-	assert.Equal(t, authorizeTemplateData{Identity: true}, template.data)
+	assert.Equal(t, authorizeTemplateData{SubDefaultManual: true, Identity: true}, template.data)
 }
 
 func TestAuthorizeWithReturnCode(t *testing.T) {
@@ -185,7 +185,7 @@ func TestAuthorizeWithReturnCode(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, w, template.w)
-	assert.Equal(t, authorizeTemplateData{ReturnCodes: true}, template.data)
+	assert.Equal(t, authorizeTemplateData{SubDefaultManual: true, ReturnCodes: true}, template.data)
 }
 
 func TestAuthorizePost(t *testing.T) {
@@ -198,6 +198,7 @@ func TestAuthorizePost(t *testing.T) {
 				"redirect_uri": {"http://localhost:5050/auth/redirect"},
 				"state":        {"my-state"},
 				"nonce":        {"my-nonce"},
+				"subject":      {"manual"},
 			},
 			session: sessionData{
 				email: "simulate-delivered@notifications.service.gov.uk",
@@ -211,6 +212,7 @@ func TestAuthorizePost(t *testing.T) {
 				"state":        {"my-state"},
 				"nonce":        {"my-nonce"},
 				"email":        {"dave@example.com"},
+				"subject":      {"manual"},
 			},
 			session: sessionData{
 				email: "dave@example.com",
@@ -273,7 +275,6 @@ func TestAuthorizePost(t *testing.T) {
 			session: sessionData{
 				email:    "simulate-delivered@notifications.service.gov.uk",
 				nonce:    "my-nonce",
-				sub:      "urn:fdc:mock-one-login:2023:QMykNslde7HiDDtluNUVQUUnFpbu1ZAKiOr/QZ6sY34=",
 				identity: true,
 				user: user{
 					firstNames:  "Sam",
@@ -304,7 +305,6 @@ func TestAuthorizePost(t *testing.T) {
 			session: sessionData{
 				email:    "simulate-delivered@notifications.service.gov.uk",
 				nonce:    "my-nonce",
-				sub:      "urn:fdc:mock-one-login:2023:QMykNslde7HiDDtluNUVQUUnFpbu1ZAKiOr/QZ6sY34=",
 				identity: true,
 				user: user{
 					firstNames:  "Charlie",
@@ -335,7 +335,6 @@ func TestAuthorizePost(t *testing.T) {
 			session: sessionData{
 				email:    "simulate-delivered@notifications.service.gov.uk",
 				nonce:    "my-nonce",
-				sub:      "urn:fdc:mock-one-login:2023:QMykNslde7HiDDtluNUVQUUnFpbu1ZAKiOr/QZ6sY34=",
 				identity: true,
 				user: user{
 					firstNames:  "Vivian",
@@ -376,7 +375,6 @@ func TestAuthorizePost(t *testing.T) {
 			session: sessionData{
 				email:    "simulate-delivered@notifications.service.gov.uk",
 				nonce:    "my-nonce",
-				sub:      "urn:fdc:mock-one-login:2023:QMykNslde7HiDDtluNUVQUUnFpbu1ZAKiOr/QZ6sY34=",
 				identity: true,
 				user: user{
 					firstNames:  "John",
@@ -407,7 +405,6 @@ func TestAuthorizePost(t *testing.T) {
 			session: sessionData{
 				email:      "simulate-delivered@notifications.service.gov.uk",
 				nonce:      "my-nonce",
-				sub:        "urn:fdc:mock-one-login:2023:QMykNslde7HiDDtluNUVQUUnFpbu1ZAKiOr/QZ6sY34=",
 				identity:   true,
 				returnCode: "X",
 			},

--- a/main_test.go
+++ b/main_test.go
@@ -64,6 +64,35 @@ func TestJwks(t *testing.T) {
 	assert.JSONEq(t, `{"keys":[{"kty":"EC","use":"sig","crv":"P-256","kid":"my-kid","x":"AQ","y":"Ag","alg":"ES256"}]}`, string(body))
 }
 
+func TestDID(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	h := did("my-controller", "my-controller#my-kid", ecdsa.PublicKey{X: big.NewInt(1), Y: big.NewInt(2)})
+	err := h(w, r)
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	assert.JSONEq(t, `{
+  "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
+  "id": "my-controller",
+  "assertionMethod": [{
+    "type": "JsonWebKey",
+    "id": "my-controller#my-kid",
+    "controller": "my-controller",
+    "publicKeyJwk": {
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "AQ",
+      "y": "Ag",
+      "alg": "ES256"
+    }
+  }]
+}`, string(body))
+}
+
 func TestToken(t *testing.T) {
 	form := url.Values{
 		"code": {"my-code"},
@@ -461,7 +490,7 @@ func TestUserInfoWithIdentity(t *testing.T) {
 	assert.Equal(t, "01406946277", data["phone"])
 	assert.Equal(t, true, data["phone_verified"])
 	assert.Equal(t, float64(1311280970), data["updated_at"])
-	assert.Contains(t, data["https://vocab.account.gov.uk/v1/coreIdentityJWT"], "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lkZW50aXR5LmFjY291bnQuZ292LnVrLyIsInN1YiI6Im15LXN1YiIsImF1ZCI6WyJ0aGVDbGllbnRJZCJdLCJleHAiOjE1Nzc5MzQ0MjUsIm5iZiI6MTU3NzkzNDI0NSwiaWF0IjoxNTc3OTM0MjQ1LCJ2b3QiOiJQMiIsInZ0bSI6Imh0dHBzOi8vb2lkYy5hY2NvdW50Lmdvdi51ay90cnVzdG1hcmsiLCJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMjAwMC0wMS0wMiJ9XSwibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJTYW0ifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJTbWl0aCJ9XSwidmFsaWRGcm9tIjoiMjAwMC0wMS0wMSJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl19fQ.")
+	assert.Contains(t, data["https://vocab.account.gov.uk/v1/coreIdentityJWT"], ".eyJpc3MiOiJodHRwczovL2lkZW50aXR5LmFjY291bnQuZ292LnVrLyIsInN1YiI6Im15LXN1YiIsImF1ZCI6WyJ0aGVDbGllbnRJZCJdLCJleHAiOjE1Nzc5MzQ0MjUsIm5iZiI6MTU3NzkzNDI0NSwiaWF0IjoxNTc3OTM0MjQ1LCJ2b3QiOiJQMiIsInZ0bSI6Imh0dHBzOi8vb2lkYy5hY2NvdW50Lmdvdi51ay90cnVzdG1hcmsiLCJ2YyI6eyJjcmVkZW50aWFsU3ViamVjdCI6eyJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMjAwMC0wMS0wMiJ9XSwibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJTYW0ifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJTbWl0aCJ9XSwidmFsaWRGcm9tIjoiMjAwMC0wMS0wMSJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJWZXJpZmlhYmxlSWRlbnRpdHlDcmVkZW50aWFsIl19fQ.")
 	assert.Equal(t, []any{map[string]any{
 		"uprn": float64(8), "buildingNumber": "1", "streetName": "2", "dependentAddressLocality": "3", "addressLocality": "4", "postalCode": "5", "addressCountry": "6", "validFrom": "7",
 	}}, data["https://vocab.account.gov.uk/v1/address"],

--- a/web/templates/authorize.gohtml
+++ b/web/templates/authorize.gohtml
@@ -9,7 +9,7 @@
           </legend>
           <div class="govuk-radios" data-module="govuk-radios">
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="user-1" name="user" type="radio" value="donor">
+              <input class="govuk-radios__input" id="user-1" name="user" type="radio" value="donor" checked>
               <label class="govuk-label govuk-radios__label" for="user-1">
                 Sam Smith (donor)
               </label>
@@ -140,19 +140,19 @@
             </div>
             <div class="govuk-radios" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-sub-2" name="subject" type="radio" value="fixed">
+                <input class="govuk-radios__input" id="f-sub-2" name="subject" type="radio" value="fixed" {{ if .SubDefaultFixed }}checked{{ end }}>
                 <label class="govuk-label govuk-radios__label" for="f-sub-2">
                   Fixed value (<em>urn:fdc:mock-one-login:2023:fixed_value</em>)
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-sub-3" name="subject" type="radio" value="random">
+                <input class="govuk-radios__input" id="f-sub-3" name="subject" type="radio" value="random" {{ if .SubDefaultRandom }}checked{{ end }}>
                 <label class="govuk-label govuk-radios__label" for="f-sub-3">
                   Random value (<em>urn:fdc:mock-one-login:2023:**********</em>)
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-sub-1" name="subject" type="radio" value="manual" data-aria-controls="cond-subject-1" aria-expanded="true">
+                <input class="govuk-radios__input" id="f-sub-1" name="subject" type="radio" value="manual" {{ if .SubDefaultManual }}checked{{ end }} data-aria-controls="cond-subject-1" aria-expanded="true">
                 <label class="govuk-label govuk-radios__label" for="f-sub-1" id="manual-label">
                   Specify manually (leave blank to generate from email)
                 </label>


### PR DESCRIPTION
See https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/prove-users-identity/#validate-the-core-identity-claim-jwt-using-a-public-key

The current key is left as a hard-coded string to not break things when this gets merged. After everything is done I will change it to be randomly generated.

Also adds the ability to set the default behaviour of `sub` (I've left the default default as `manual`, but it will now select the radio option to make that obvious), this is so we can set it to random by default and not have people getting confused.