### PR TITLE
MLPAB-2559 - use main prefix for lifecycle

### DIFF
--- a/.github/workflows/_docker_build_scan_push.yml
+++ b/.github/workflows/_docker_build_scan_push.yml
@@ -105,6 +105,9 @@ jobs:
 
       - name: Trivy scan
         uses: aquasecurity/trivy-action@0.24.0
+        env:
+          TRIVY_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-java-db:1
         with:
           image-ref: ${{ steps.docker_tags.outputs.semver_tag }}
           severity: "HIGH,CRITICAL"

--- a/.github/workflows/_docker_build_scan_push.yml
+++ b/.github/workflows/_docker_build_scan_push.yml
@@ -82,7 +82,7 @@ jobs:
         id: docker_tags
         run: |
           if ${{ inputs.build_latest }}; then
-            echo "tags=$ECR_REGISTRY/$ECR_REPOSITORY:latest,$ECR_REGISTRY/$ECR_REPOSITORY:$SEMVER_TAG" >> $GITHUB_OUTPUT
+            echo "tags=$ECR_REGISTRY/$ECR_REPOSITORY:latest,$ECR_REGISTRY/$ECR_REPOSITORY:$SEMVER_TAG,$ECR_REGISTRY/$ECR_REPOSITORY:main-$SEMVER_TAG" >> $GITHUB_OUTPUT
           else
             echo "tags=$ECR_REGISTRY/$ECR_REPOSITORY:$SEMVER_TAG" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
# Purpose

Use lifecycle to retain last x images when tagged with `main-` prefix

Fixes MLPAB-2559

## Approach

- add `main` to image tag during path to live to preserve with ECR lifecycle
- use pass-through cache for trivy image scan