### PR TITLE
Remove field to set custom subject

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -25,14 +25,14 @@ defaults:
 jobs:
   branch_name:
     name: "Generate a safe branch name"
-    uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-branch-name.yml@main
+    uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-branch-name.yml@v3.10.0
 
   semver_tag:
     needs: [branch_name]
     name: "Generate the semver tag value"
-    uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-semver-tag.yml@main
+    uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-semver-tag.yml@v3.10.0
     with:
-      branch_name: "${{ needs.branch_name.outputs.branch_name }}"
+      branch_name: "${{ needs.branch_name.outputs.safe }}"
     secrets: inherit
 
   build_scan_push:

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -25,14 +25,14 @@ defaults:
 jobs:
   branch_name:
     name: "Generate a safe branch name"
-    uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-branch-name.yml@main
+    uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-branch-name.yml@v3.10.0
 
   semver_tag:
     needs: [branch_name]
     name: "Generate the semver tag value"
-    uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-semver-tag.yml@main
+    uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-semver-tag.yml@v3.10.0
     with:
-      branch_name: "${{ needs.branch_name.outputs.branch_name }}"
+      branch_name: "${{ needs.branch_name.outputs.safe }}"
     secrets: inherit
 
   build_scan_push:

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	randomString = func(prefix string, length int) string {
+	randomString = func(_ string, _ int) string {
 		return "random"
 	}
 
@@ -146,7 +146,7 @@ func TestAuthorize(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, w, template.w)
-	assert.Equal(t, authorizeTemplateData{SubDefaultManual: true}, template.data)
+	assert.Equal(t, authorizeTemplateData{SubDefaultEmail: true}, template.data)
 }
 
 func TestAuthorizeWithIdentity(t *testing.T) {
@@ -165,7 +165,7 @@ func TestAuthorizeWithIdentity(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, w, template.w)
-	assert.Equal(t, authorizeTemplateData{SubDefaultManual: true, Identity: true}, template.data)
+	assert.Equal(t, authorizeTemplateData{SubDefaultEmail: true, Identity: true}, template.data)
 }
 
 func TestAuthorizeWithReturnCode(t *testing.T) {
@@ -185,7 +185,7 @@ func TestAuthorizeWithReturnCode(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, w, template.w)
-	assert.Equal(t, authorizeTemplateData{SubDefaultManual: true, ReturnCodes: true}, template.data)
+	assert.Equal(t, authorizeTemplateData{SubDefaultEmail: true, ReturnCodes: true}, template.data)
 }
 
 func TestAuthorizePost(t *testing.T) {
@@ -198,7 +198,7 @@ func TestAuthorizePost(t *testing.T) {
 				"redirect_uri": {"http://localhost:5050/auth/redirect"},
 				"state":        {"my-state"},
 				"nonce":        {"my-nonce"},
-				"subject":      {"manual"},
+				"subject":      {"email"},
 			},
 			session: sessionData{
 				email: "simulate-delivered@notifications.service.gov.uk",
@@ -212,41 +212,12 @@ func TestAuthorizePost(t *testing.T) {
 				"state":        {"my-state"},
 				"nonce":        {"my-nonce"},
 				"email":        {"dave@example.com"},
-				"subject":      {"manual"},
+				"subject":      {"email"},
 			},
 			session: sessionData{
 				email: "dave@example.com",
 				nonce: "my-nonce",
 				sub:   "urn:fdc:mock-one-login:2023:ezQhE1D/Vnlwl04eK5jTGaYBlp50/RqVe8iJuDMtAOs=",
-			},
-		},
-		"sign-in with sub": {
-			form: url.Values{
-				"redirect_uri": {"http://localhost:5050/auth/redirect"},
-				"state":        {"my-state"},
-				"nonce":        {"my-nonce"},
-				"subject":      {"manual"},
-				"subjectValue": {"dave"},
-			},
-			session: sessionData{
-				email: "simulate-delivered@notifications.service.gov.uk",
-				nonce: "my-nonce",
-				sub:   "dave",
-			},
-		},
-		"sign-in with email and sub": {
-			form: url.Values{
-				"redirect_uri": {"http://localhost:5050/auth/redirect"},
-				"state":        {"my-state"},
-				"nonce":        {"my-nonce"},
-				"email":        {"dave@example.com"},
-				"subject":      {"manual"},
-				"subjectValue": {"dave"},
-			},
-			session: sessionData{
-				email: "dave@example.com",
-				nonce: "my-nonce",
-				sub:   "dave",
 			},
 		},
 		"sign-in with email and fixed sub": {
@@ -404,7 +375,7 @@ func TestAuthorizePost(t *testing.T) {
 				"nonce":        {"my-nonce"},
 				"vtr":          {`["Cl.Cm.P2"]`},
 				"claims":       {`{"userinfo":{"https://vocab.account.gov.uk/v1/coreIdentityJWT":null,"https://vocab.account.gov.uk/v1/returnCode":null}}`},
-				"return-code":  {"X"},
+				"user":         {"return-code:X"},
 			},
 			session: sessionData{
 				email:      "simulate-delivered@notifications.service.gov.uk",
@@ -589,7 +560,7 @@ func TestUserInfoWithIdentityUnsuccessfulIdentityCheckWithReturnCode(t *testing.
 	assert.Equal(t, float64(1311280970), data["updated_at"])
 	assert.Contains(t,
 		data["https://vocab.account.gov.uk/v1/returnCode"],
-		map[string]interface{}{"code": "X"},
+		map[string]any{"code": "X"},
 	)
 }
 

--- a/web/templates/authorize.gohtml
+++ b/web/templates/authorize.gohtml
@@ -110,13 +110,13 @@
             {{ if .ReturnCodes }}
               <div class="govuk-radios__divider">or</div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="unsuccessful-id-check-1" name="return-code" type="radio" value="X">
+                <input class="govuk-radios__input" id="unsuccessful-id-check-1" name="user" type="radio" value="return-code:X">
                 <label class="govuk-label govuk-radios__label" for="unsuccessful-id-check-1">
                   Unable to prove identity (X)
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="unsuccessful-id-check-2" name="return-code" type="radio" value="T">
+                <input class="govuk-radios__input" id="unsuccessful-id-check-2" name="user" type="radio" value="return-code:T">
                 <label class="govuk-label govuk-radios__label" for="unsuccessful-id-check-2">
                   Failed identity check (T)
                 </label>
@@ -142,25 +142,20 @@
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="f-sub-2" name="subject" type="radio" value="fixed" {{ if .SubDefaultFixed }}checked{{ end }}>
                 <label class="govuk-label govuk-radios__label" for="f-sub-2">
-                  Fixed value (<em>urn:fdc:mock-one-login:2023:fixed_value</em>)
+                  Fixed (<em>urn:fdc:mock-one-login:2023:fixed_value</em>)
                 </label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="f-sub-3" name="subject" type="radio" value="random" {{ if .SubDefaultRandom }}checked{{ end }}>
                 <label class="govuk-label govuk-radios__label" for="f-sub-3">
-                  Random value (<em>urn:fdc:mock-one-login:2023:**********</em>)
+                  Random (<em>urn:fdc:mock-one-login:2023:${random("a-zA-Z0-9", 20)}</em>)
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="f-sub-1" name="subject" type="radio" value="manual" {{ if .SubDefaultManual }}checked{{ end }} data-aria-controls="cond-subject-1" aria-expanded="true">
-                <label class="govuk-label govuk-radios__label" for="f-sub-1" id="manual-label">
-                  Specify manually (leave blank to generate from email)
+                <input class="govuk-radios__input" id="f-sub-1" name="subject" type="radio" value="email" {{ if .SubDefaultEmail }}checked{{ end }}>
+                <label class="govuk-label govuk-radios__label" for="f-sub-1">
+                  Email (<em>urn:fdc:mock-one-login:2023:${base64(sha256(email))}</em>)
                 </label>
-              </div>
-              <div class="govuk-radios__conditional" id="cond-subject-1">
-                <div class="govuk-form-group">
-                  <input class="govuk-input govuk-!-width-one-half" id="manual-subject" name="subjectValue" spellcheck="false" aria-describedby="manual-label">
-                </div>
               </div>
             </div>
           </fieldset>
@@ -170,7 +165,7 @@
       <div class="govuk-form-group">
         <label class="govuk-label govuk-label--m" for="f-email">Email</label>
         <div class="govuk-hint">Set email in OneLogin UserInfo (leave empty to set as test email address)</div>
-        <input class="govuk-input" type="text" name="email" id="f-email" value="{{ .Email }}" />
+        <input class="govuk-input" type="text" name="email" id="f-email" value="{{ .Email }}" placeholder="simulate-delivered@notifications.service.gov.uk" />
       </div>
     {{ end }}
 


### PR DESCRIPTION
This removes the ability to set an email address here, which could then later cause confusion as to what data has been set. Now all subjects will have the same `urn:fdc:...` prefix.

Also fixes the naming of the identity radio inputs, so that a user can't be selected at the same time as a return code.
